### PR TITLE
spellchecker: bump hoek

### DIFF
--- a/spellchecker/package-lock.json
+++ b/spellchecker/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "figma-spellcheck",
+  "name": "figma-api-spellcheck",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -159,10 +159,7 @@
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -251,10 +248,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw=="
         }
       }
     },
@@ -406,7 +400,6 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
         "sntp": "2.1.0"
       }
     },
@@ -417,9 +410,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -742,10 +735,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/spellchecker/package.json
+++ b/spellchecker/package.json
@@ -20,6 +20,7 @@
     "@types/request": "^2.47.0",
     "@types/traverse": "^0.6.30",
     "commander": "2.13.0",
+    "hoek": "5.0.3",
     "request": "^2.83.0",
     "spellchecker": "^3.4.4",
     "traverse": "^0.6.6",


### PR DESCRIPTION
GitHub alerted us to [this vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-3728) in versions of `hoek` below 5.0.3.