### PR TITLE
spellcheck: bump vulnerable dependencies

### DIFF
--- a/spellchecker/package-lock.json
+++ b/spellchecker/package-lock.json
@@ -311,9 +311,9 @@
       "dev": true
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -538,10 +538,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-      "dev": true
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -648,6 +647,12 @@
         "text-encoding": "^0.6.4"
       },
       "dependencies": {
+        "just-extend": {
+          "version": "1.1.27",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+          "dev": true
+        },
         "lolex": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",

--- a/spellchecker/package.json
+++ b/spellchecker/package.json
@@ -21,6 +21,8 @@
     "@types/traverse": "^0.6.30",
     "commander": "2.13.0",
     "cryptiles": ">=4.1.2",
+    "extend": ">=3.0.2",
+    "just-extend": ">=4.0.0",
     "hoek": "5.0.3",
     "request": "^2.83.0",
     "spellchecker": "^3.4.4",


### PR DESCRIPTION
GitHub alerted us to a couple of vulnerable dependencies; Figma folks can view the details [here](https://github.com/figma/figma-api-demo/network/alerts). This PR upgrades `spellcheck` to patched dependencies.

Fixes: https://app.asana.com/0/532064966655668/1110468031342902/f