### PR TITLE
Remove unused componentList from figma-to-react example

### DIFF
--- a/figma-to-react/main.js
+++ b/figma-to-react/main.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const figma = require('./lib/figma');
 
 const headers = new fetch.Headers();
-const componentList = [];
 let devToken = process.env.DEV_TOKEN;
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
Remove unused componentList from figma-to-react example.

This array is not referenced anywhere.